### PR TITLE
Update .requirements.txt

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -1,3 +1,3 @@
 box-sdk-gen
-getpass
 python-dotenv
+jupyter


### PR DESCRIPTION
Fix: Remove getpass from requirements.txt

getpass is part of Python's standard library and should not be listed as a pip dependency. This was causing installation failures with 'No matching distribution found for getpass' error.

**Problem:**
Users following the setup instructions encounter a blocking error when running `pip install -r .requirements.txt`

**Solution:**
Remove getpass from requirements.txt since it's available as a standard library import

**Testing:**
- Confirmed `pip install -r .requirements.txt` now works successfully
- All required dependencies (box-sdk-gen, python-dotenv, jupyter) install correctly